### PR TITLE
Add shebang to run directly

### DIFF
--- a/latex2python.py
+++ b/latex2python.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re
 import argparse
 


### PR DESCRIPTION
By adding this shebang line, users can run `./latex2python.py` instead of `python latex2python.py`. When I first downloaded this, I couldn't understand why it was throwing so many errors, but it was because it was running as a shell command!